### PR TITLE
Increase flexibility of /remind statement

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -43,7 +43,7 @@ describe('getReminder', () => {
       who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
     });
   });
-  test('can parse reminder within line', () => {
+  test('does not parse reminder within line', () => {
     const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
     const reminder = getReminder({
       ...issueContext,
@@ -52,9 +52,7 @@ describe('getReminder', () => {
       }
     }, REFERENCE_DATE);
 
-    expect(reminder).toEqual({
-      who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
-    });
+    expect(reminder).toBeNull();
   });
   test('skips reminder in quote', () => {
     const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);

--- a/index.test.js
+++ b/index.test.js
@@ -19,7 +19,7 @@ describe('getReminder', () => {
     });
 
     expect(reminder).toBeNull();
-  })
+  });
   test('returns null if the command is not remind', () => {
     const reminder = getReminder({
       ...issueContext,
@@ -29,6 +29,89 @@ describe('getReminder', () => {
     });
 
     expect(reminder).toBeNull();
+  });
+  test('can parse multiline comments', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	body: "This is a test\r\n/remind me to do this in one day\r\nwith some text"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toEqual({
+	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+    });
+  });
+  test('can parse reminder within line', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	      body: "This is a test: /remind me to do this in one day"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toEqual({
+	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+    });
+  });
+  test('skips reminder in quote', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	body: "This is a test\r\n> with some text\r\n> /remind me to do this in one day"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toBeNull();
+  });
+  test('skips reminder in code block', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	body: "This is a test\r\n```\r\n/remind me to do this in one day\r\n```"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toBeNull();
+  });
+  test('skips reminder in code block 2', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	body: "This is a test\r\n```python\r\n/remind me to do this in one day\r\n```"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toBeNull();
+  });
+  test('skips reminder in inline code', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	      body: "This is a test: `/remind me to do this in one day`"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toBeNull();
+  });
+  test('works again after code block', () => {
+    const REFERENCE_DATE = new Date(2017, 6, 5, 4, 3, 2, 0);
+    const reminder = getReminder({
+      ...issueContext,
+      comment: {
+	body: "This is a test\r\n```\r\ncode here!\r\n```\r\n/remind me to do this in one day"
+      }
+    }, REFERENCE_DATE);
+
+    expect(reminder).toEqual({
+	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+    });
   });
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -35,12 +35,12 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	body: "This is a test\r\n/remind me to do this in one day\r\nwith some text"
+        body: "This is a test\r\n/remind me to do this in one day\r\nwith some text"
       }
     }, REFERENCE_DATE);
 
     expect(reminder).toEqual({
-	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+      who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
     });
   });
   test('can parse reminder within line', () => {
@@ -48,12 +48,12 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	      body: "This is a test: /remind me to do this in one day"
+        body: "This is a test: /remind me to do this in one day"
       }
     }, REFERENCE_DATE);
 
     expect(reminder).toEqual({
-	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+      who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
     });
   });
   test('skips reminder in quote', () => {
@@ -61,7 +61,7 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	body: "This is a test\r\n> with some text\r\n> /remind me to do this in one day"
+        body: "This is a test\r\n> with some text\r\n> /remind me to do this in one day"
       }
     }, REFERENCE_DATE);
 
@@ -72,7 +72,7 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	body: "This is a test\r\n```\r\n/remind me to do this in one day\r\n```"
+        body: "This is a test\r\n```\r\n/remind me to do this in one day\r\n```"
       }
     }, REFERENCE_DATE);
 
@@ -83,7 +83,7 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	body: "This is a test\r\n```python\r\n/remind me to do this in one day\r\n```"
+        body: "This is a test\r\n```python\r\n/remind me to do this in one day\r\n```"
       }
     }, REFERENCE_DATE);
 
@@ -94,7 +94,7 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	      body: "This is a test: `/remind me to do this in one day`"
+        body: "This is a test: `/remind me to do this in one day`"
       }
     }, REFERENCE_DATE);
 
@@ -105,12 +105,12 @@ describe('getReminder', () => {
     const reminder = getReminder({
       ...issueContext,
       comment: {
-	body: "This is a test\r\n```\r\ncode here!\r\n```\r\n/remind me to do this in one day"
+        body: "This is a test\r\n```\r\ncode here!\r\n```\r\n/remind me to do this in one day"
       }
     }, REFERENCE_DATE);
 
     expect(reminder).toEqual({
-	    who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
+      who: 'Codertocat', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'do this'
     });
   });
 });

--- a/utilities.js
+++ b/utilities.js
@@ -5,12 +5,12 @@ const parseReminder = require('parse-reminder');
 //   when: 2017-09-12T12:00:00.000Z }
 function getReminder(context, referenceDate = null) {
   const body = context.comment.body;
-  var remindLine = null;
-  var inCode = false;
+  let remindLine = null;
+  let inCode = false;
 
   const lines = body.split('\n');
   for (let i=0; i<lines.length; i++) {
-    var line = lines[i].trim('\r');
+    const line = lines[i].trim('\r');
 
     // handle code blocks
     if (line.startsWith('```')) {
@@ -26,10 +26,10 @@ function getReminder(context, referenceDate = null) {
     }
 
     // find /remind in line.
-    var words = line.split(' ');
-    var foundRemind = false;
+    const words = line.split(' ');
+    let foundRemind = false;
     for (let j=0; j<words.length; j++) {
-      var word = words[j];
+      const word = words[j];
       if (word === '/remind') {
         foundRemind = true;
         remindLine = words.slice(j).join(' ');

--- a/utilities.js
+++ b/utilities.js
@@ -21,7 +21,7 @@ function getReminder(context, referenceDate = null) {
       continue;
 
     // handle quoted text
-    if (line.trim(' ').startsWith('>')) {
+    if (line.startsWith('>')) {
       continue;
     }
 

--- a/utilities.js
+++ b/utilities.js
@@ -10,7 +10,7 @@ function getReminder(context, referenceDate = null) {
 
   const lines = body.split('\n');
   for (let i=0; i<lines.length; i++) {
-    const line = lines[i].trim('\r');
+    const line = lines[i].trim();
 
     // handle code blocks
     if (line.startsWith('```')) {

--- a/utilities.js
+++ b/utilities.js
@@ -25,15 +25,12 @@ function getReminder(context, referenceDate = null) {
       continue;
     }
 
-    // find /remind in line.
-    const words = line.split(' ');
-    for (let j=0; j<words.length; j++) {
-      const word = words[j];
-      if (word === '/remind') {
-        remindLine = words.slice(j).join(' ');
-        break;
-      }
+    // find /remind at the beginning of the line.
+    if (line.startsWith('/remind ')) {
+      remindLine = line;
+      break;
     }
+
     if (remindLine !== null) {
       break;
     }

--- a/utilities.js
+++ b/utilities.js
@@ -20,18 +20,9 @@ function getReminder(context, referenceDate = null) {
     if (inCode)
       continue;
 
-    // handle quoted text
-    if (line.startsWith('>')) {
-      continue;
-    }
-
     // find /remind at the beginning of the line.
     if (line.startsWith('/remind ')) {
       remindLine = line;
-      break;
-    }
-
-    if (remindLine !== null) {
       break;
     }
   }

--- a/utilities.js
+++ b/utilities.js
@@ -27,16 +27,14 @@ function getReminder(context, referenceDate = null) {
 
     // find /remind in line.
     const words = line.split(' ');
-    let foundRemind = false;
     for (let j=0; j<words.length; j++) {
       const word = words[j];
       if (word === '/remind') {
-        foundRemind = true;
         remindLine = words.slice(j).join(' ');
         break;
       }
     }
-    if (foundRemind) {
+    if (remindLine !== null) {
       break;
     }
   }

--- a/utilities.js
+++ b/utilities.js
@@ -5,16 +5,47 @@ const parseReminder = require('parse-reminder');
 //   when: 2017-09-12T12:00:00.000Z }
 function getReminder(context, referenceDate = null) {
   const body = context.comment.body;
-  if (!body.startsWith('/')) {
+  var remindLine = null;
+  var inCode = false;
+
+  const lines = body.split('\n');
+  for (let i=0; i<lines.length; i++) {
+    var line = lines[i].trim('\r');
+
+    // handle code blocks
+    if (line.startsWith('```')) {
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode)
+      continue;
+
+    // handle quoted text
+    if (line.trim(' ').startsWith('>')) {
+      continue;
+    }
+
+    // find /remind in line.
+    var words = line.split(' ');
+    var foundRemind = false;
+    for (let j=0; j<words.length; j++) {
+      var word = words[j];
+      if (word === '/remind') {
+        foundRemind = true;
+        remindLine = words.slice(j).join(' ');
+        break;
+      }
+    }
+    if (foundRemind) {
+      break;
+    }
+  }
+
+  if (remindLine === null) {
     return null;
   }
 
-  const firstWord = body.slice(1, body.indexOf(' '));
-  if (firstWord !== 'remind') {
-    return null;
-  }
-
-  const reminder = parseReminder(body.slice(1), referenceDate);
+  const reminder = parseReminder(remindLine.slice(1), referenceDate);
 
   if (!reminder) {
     throw new Error(`Unable to parse reminder: remind ${body}`);


### PR DESCRIPTION
Hi there! Thanks for making this tool! This PR increases the flexibility of finding the /remind line in the comment message. It supports the remind line being on a different line or within a line, and understands to skip code blocks and quoted text. Fixes #14.

(Code style could probably be improved, so feel free to make edits to conform to your codebase!)